### PR TITLE
Push to origin/<branch-name> instead of origin/HEAD

### DIFF
--- a/src/hugit/events.cljs
+++ b/src/hugit/events.cljs
@@ -195,12 +195,13 @@
 (rf/reg-event-db
  :push
  (fn [db _]
-   (.then (git/push-promise)
-          (fn [{:keys [command stdout stderr]}]
-            (println "\n$" command)
-            (println stdout)
-            (println stderr)
-            (println)))
+   (let [branch (get-in db [:repo :branch-name])]
+     (.then (git/push-promise branch)
+            (fn [{:keys [command stdout stderr]}]
+              (println "\n$" command)
+              (println stdout)
+              (println stderr)
+              (println))))
    db))
 
 (rf/reg-event-db

--- a/src/hugit/git.cljs
+++ b/src/hugit/git.cljs
@@ -176,8 +176,8 @@
   (exec "git commit -m \"" msg "\""))
 
 (defn push-promise
-  []
-  (exec-promise "git push origin HEAD"))
+  [branch-name]
+  (exec-promise "git push -u origin " branch-name))
 
 (defn branch-status-promise
   ([branch-name]

--- a/src/hugit/util.cljs
+++ b/src/hugit/util.cljs
@@ -10,6 +10,12 @@
 (defn toast> [& msgs]
   (rf/dispatch-sync (vec (cons :toast msgs))))
 
+(defn timeout [ms]
+  (js/Promise.
+   (fn [resolve]
+     (js/setTimeout #(resolve ms)
+                    ms))))
+
 (defn nth-weighted-item
   [weighted-items weight-fn n]
   (let [repeated-weighted-items (map #(repeat (weight-fn %) %)


### PR DESCRIPTION
* Push to `-u origin/<branch-name>` instead of `origin HEAD`
* Bugfix: disappearing branch-status